### PR TITLE
Fixes comment typo in Hello World example.

### DIFF
--- a/examples/full_buffer/HelloWorld/HelloWorld.ino
+++ b/examples/full_buffer/HelloWorld/HelloWorld.ino
@@ -99,7 +99,7 @@ void setup(void) {
 }
 
 void loop(void) {
-  u8g2.clearBuffer();					// clear the internal menory
+  u8g2.clearBuffer();					// clear the internal memory
   u8g2.setFont(u8g2_font_ncenB14_tr);	// choose a suitable font
   u8g2.drawStr(0,20,"Hello World!");	// write something to the internal memory
   u8g2.sendBuffer();					// transfer internal memory to the display


### PR DESCRIPTION
Very minor text change. 
`menory` to `memory`
