### PR TITLE
Add support for SMR19264B

### DIFF
--- a/src/U8g2lib.h
+++ b/src/U8g2lib.h
@@ -23226,6 +23226,12 @@ class U8G2_KS0108_ERM19264_F : public U8G2 {
     u8x8_SetPin_KS0108(getU8x8(), d0, d1, d2, d3, d4, d5, d6, d7, enable, dc, cs0, cs1, cs2, reset);
   }
 };
+class U8G2_KS0108_SMR19264B_F : public U8G2 {
+  public: U8G2_KS0108_SMR19264B_F(const u8g2_cb_t *rotation, uint8_t d0, uint8_t d1, uint8_t d2, uint8_t d3, uint8_t d4, uint8_t d5, uint8_t d6, uint8_t d7, uint8_t enable, uint8_t dc, uint8_t cs0, uint8_t cs1, uint8_t reset = U8X8_PIN_NONE) : U8G2() {
+    u8g2_Setup_ks0108_smr19264b_f(&u8g2, rotation, u8x8_byte_arduino_ks0108, u8x8_gpio_and_delay_arduino);
+    u8x8_SetPin_KS0108(getU8x8(), d0, d1, d2, d3, d4, d5, d6, d7, enable, dc, cs0, cs1, U8X8_PIN_NONE, reset);
+  }
+};
 class U8G2_T7932_150X32_1 : public U8G2 {
   public: U8G2_T7932_150X32_1(const u8g2_cb_t *rotation, uint8_t d0, uint8_t d1, uint8_t d2, uint8_t d3, uint8_t d4, uint8_t d5, uint8_t d6, uint8_t d7, uint8_t enable, uint8_t dc, uint8_t cs0, uint8_t cs1, uint8_t cs2, uint8_t reset = U8X8_PIN_NONE) : U8G2() {
     u8g2_Setup_t7932_150x32_1(&u8g2, rotation, u8x8_byte_arduino_ks0108, u8x8_gpio_and_delay_arduino);

--- a/src/clib/u8g2.h
+++ b/src/clib/u8g2.h
@@ -1481,6 +1481,7 @@ void u8g2_Setup_ks0108_128x64_f(u8g2_t *u8g2, const u8g2_cb_t *rotation, u8x8_ms
 void u8g2_Setup_ks0108_erm19264_1(u8g2_t *u8g2, const u8g2_cb_t *rotation, u8x8_msg_cb byte_cb, u8x8_msg_cb gpio_and_delay_cb);
 void u8g2_Setup_ks0108_erm19264_2(u8g2_t *u8g2, const u8g2_cb_t *rotation, u8x8_msg_cb byte_cb, u8x8_msg_cb gpio_and_delay_cb);
 void u8g2_Setup_ks0108_erm19264_f(u8g2_t *u8g2, const u8g2_cb_t *rotation, u8x8_msg_cb byte_cb, u8x8_msg_cb gpio_and_delay_cb);
+void u8g2_Setup_ks0108_smr19264b_f(u8g2_t *u8g2, const u8g2_cb_t *rotation, u8x8_msg_cb byte_cb, u8x8_msg_cb gpio_and_delay_cb);
 void u8g2_Setup_t7932_150x32_1(u8g2_t *u8g2, const u8g2_cb_t *rotation, u8x8_msg_cb byte_cb, u8x8_msg_cb gpio_and_delay_cb);
 void u8g2_Setup_t7932_150x32_2(u8g2_t *u8g2, const u8g2_cb_t *rotation, u8x8_msg_cb byte_cb, u8x8_msg_cb gpio_and_delay_cb);
 void u8g2_Setup_t7932_150x32_f(u8g2_t *u8g2, const u8g2_cb_t *rotation, u8x8_msg_cb byte_cb, u8x8_msg_cb gpio_and_delay_cb);

--- a/src/clib/u8g2_d_setup.c
+++ b/src/clib/u8g2_d_setup.c
@@ -7335,6 +7335,15 @@ void u8g2_Setup_ks0108_erm19264_f(u8g2_t *u8g2, const u8g2_cb_t *rotation, u8x8_
   buf = u8g2_m_24_8_f(&tile_buf_height);
   u8g2_SetupBuffer(u8g2, buf, tile_buf_height, u8g2_ll_hvline_vertical_top_lsb, rotation);
 }
+/* ks0108 f */
+void u8g2_Setup_ks0108_smr19264b_f(u8g2_t *u8g2, const u8g2_cb_t *rotation, u8x8_msg_cb byte_cb, u8x8_msg_cb gpio_and_delay_cb)
+{
+  uint8_t tile_buf_height;
+  uint8_t *buf;
+  u8g2_SetupDisplay(u8g2, u8x8_d_ks0108_smr19264b, u8x8_cad_001, byte_cb, gpio_and_delay_cb);
+  buf = u8g2_m_24_8_f(&tile_buf_height);
+  u8g2_SetupBuffer(u8g2, buf, tile_buf_height, u8g2_ll_hvline_vertical_top_lsb, rotation);
+}
 /* t7932 */
 /* t7932 1 */
 void u8g2_Setup_t7932_150x32_1(u8g2_t *u8g2, const u8g2_cb_t *rotation, u8x8_msg_cb byte_cb, u8x8_msg_cb gpio_and_delay_cb)

--- a/src/clib/u8x8.h
+++ b/src/clib/u8x8.h
@@ -1002,6 +1002,7 @@ uint8_t u8x8_d_uc1638_192x96(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, void *a
 uint8_t u8x8_d_uc1638_240x128(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, void *arg_ptr);
 uint8_t u8x8_d_ks0108_128x64(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, void *arg_ptr);
 uint8_t u8x8_d_ks0108_erm19264(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, void *arg_ptr);
+uint8_t u8x8_d_ks0108_smr19264b(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, void *arg_ptr);
 uint8_t u8x8_d_t7932_150x32(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, void *arg_ptr); /* t7932 and hd44102 are compatible */
 uint8_t u8x8_d_hd44102_100x64(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, void *arg_ptr); /* t7932 and hd44102 are compatible */
 uint8_t u8x8_d_sbn1661_122x32(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, void *arg_ptr);

--- a/src/clib/u8x8_d_ks0108.c
+++ b/src/clib/u8x8_d_ks0108.c
@@ -342,3 +342,103 @@ uint8_t u8x8_d_ks0108_erm19264(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, void 
   return 1;
 }
 
+/* Simair SMR19264B https://www.aliexpress.us/item/3256803610035008.html */
+/* left: 00, middle: 01, right: 10, no chip select: 11 */
+uint8_t u8x8_d_ks0108_smr19264b(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, void *arg_ptr)
+{
+  const int LEFT = 0;
+  const int MIDDLE = 1;
+  const int RIGHT = 2;
+  const int NO_CS = 3;
+
+  struct u8x8_ks0108_vars v;
+  switch(msg)
+  {
+    case U8X8_MSG_DISPLAY_SETUP_MEMORY:
+      u8x8_d_helper_display_setup_memory(u8x8, &u8x8_ks0108_192x64_display_info);
+      break;
+    case U8X8_MSG_DISPLAY_INIT:
+      u8x8_d_helper_display_init(u8x8);
+
+      u8x8->cad_cb(u8x8, U8X8_MSG_CAD_START_TRANSFER, LEFT, NULL);
+      u8x8_cad_SendSequence(u8x8, u8x8_d_ks0108_init_seq);
+      u8x8->cad_cb(u8x8, U8X8_MSG_CAD_END_TRANSFER, NO_CS, NULL);
+
+      u8x8->cad_cb(u8x8, U8X8_MSG_CAD_START_TRANSFER, MIDDLE, NULL);
+      u8x8_cad_SendSequence(u8x8, u8x8_d_ks0108_init_seq);
+      u8x8->cad_cb(u8x8, U8X8_MSG_CAD_END_TRANSFER, NO_CS, NULL);
+
+      u8x8->cad_cb(u8x8, U8X8_MSG_CAD_START_TRANSFER, RIGHT, NULL);
+      u8x8_cad_SendSequence(u8x8, u8x8_d_ks0108_init_seq);
+      u8x8->cad_cb(u8x8, U8X8_MSG_CAD_END_TRANSFER, NO_CS, NULL);
+      break;
+    case U8X8_MSG_DISPLAY_SET_POWER_SAVE:
+
+      if ( arg_int == 0 )
+      {
+      u8x8->cad_cb(u8x8, U8X8_MSG_CAD_START_TRANSFER, LEFT, NULL);
+      u8x8_cad_SendSequence(u8x8, u8x8_d_ks0108_powersave0_seq);
+      u8x8->cad_cb(u8x8, U8X8_MSG_CAD_END_TRANSFER, NO_CS, NULL);
+
+      u8x8->cad_cb(u8x8, U8X8_MSG_CAD_START_TRANSFER, MIDDLE, NULL);
+      u8x8_cad_SendSequence(u8x8, u8x8_d_ks0108_powersave0_seq);
+      u8x8->cad_cb(u8x8, U8X8_MSG_CAD_END_TRANSFER, NO_CS, NULL);
+
+      u8x8->cad_cb(u8x8, U8X8_MSG_CAD_START_TRANSFER, RIGHT, NULL);
+      u8x8_cad_SendSequence(u8x8, u8x8_d_ks0108_powersave0_seq);
+      u8x8->cad_cb(u8x8, U8X8_MSG_CAD_END_TRANSFER, NO_CS, NULL);
+
+      }
+      else
+      {
+      u8x8->cad_cb(u8x8, U8X8_MSG_CAD_START_TRANSFER, LEFT, NULL);
+      u8x8_cad_SendSequence(u8x8, u8x8_d_ks0108_powersave1_seq);
+      u8x8->cad_cb(u8x8, U8X8_MSG_CAD_END_TRANSFER, NO_CS, NULL);
+
+      u8x8->cad_cb(u8x8, U8X8_MSG_CAD_START_TRANSFER, MIDDLE, NULL);
+      u8x8_cad_SendSequence(u8x8, u8x8_d_ks0108_powersave1_seq);
+      u8x8->cad_cb(u8x8, U8X8_MSG_CAD_END_TRANSFER, NO_CS, NULL);
+
+      u8x8->cad_cb(u8x8, U8X8_MSG_CAD_START_TRANSFER, RIGHT, NULL);
+      u8x8_cad_SendSequence(u8x8, u8x8_d_ks0108_powersave1_seq);
+      u8x8->cad_cb(u8x8, U8X8_MSG_CAD_END_TRANSFER, NO_CS, NULL);
+
+      }
+      break;
+// The KS0108 can not mirror the cols and rows, use U8g2 for rotation
+//    case U8X8_MSG_DISPLAY_SET_FLIP_MODE:
+//      break;
+// The KS0108 has no internal contrast command
+//    case U8X8_MSG_DISPLAY_SET_CONTRAST:
+//      break;
+    case U8X8_MSG_DISPLAY_DRAW_TILE:
+
+      v.ptr = ((u8x8_tile_t *)arg_ptr)->tile_ptr;
+      v.x = ((u8x8_tile_t *)arg_ptr)->x_pos;
+      v.c = ((u8x8_tile_t *)arg_ptr)->cnt;
+      v.arg_int = arg_int;
+
+      if ( v.x < 8 )
+      {
+      u8x8->cad_cb(u8x8, U8X8_MSG_CAD_START_TRANSFER, LEFT, NULL);
+      u8x8_ks0108_out(u8x8, &v, arg_ptr);
+      u8x8->cad_cb(u8x8, U8X8_MSG_CAD_END_TRANSFER, NO_CS, NULL);
+      }
+      if ( v.x < 16 )
+      {
+      u8x8->cad_cb(u8x8, U8X8_MSG_CAD_START_TRANSFER, MIDDLE, NULL);
+      u8x8_ks0108_out(u8x8, &v, arg_ptr);
+      u8x8->cad_cb(u8x8, U8X8_MSG_CAD_END_TRANSFER, NO_CS, NULL);
+      }
+      if ( v.x < 24 )
+      {
+      u8x8->cad_cb(u8x8, U8X8_MSG_CAD_START_TRANSFER, RIGHT, NULL);
+      u8x8_ks0108_out(u8x8, &v, arg_ptr);
+      u8x8->cad_cb(u8x8, U8X8_MSG_CAD_END_TRANSFER, NO_CS, NULL);
+      }
+      break;
+    default:
+      return 0;
+  }
+  return 1;
+}


### PR DESCRIPTION
The SMR19264B is a 192x64 graphic LCD module with KS0108 controllers. 

The interface is very similar to the erm19264 module already supported by U8g2, except that the SMR19264B uses a 2-bit chip-select instead of 3-bit.

I bought some from https://www.aliexpress.us/item/3256803610035008.html and have been using them in a PlatformIO ESP32 Arduino project with this change.

